### PR TITLE
Fix dependencies to make project buildable

### DIFF
--- a/facteur.opam
+++ b/facteur.opam
@@ -15,9 +15,9 @@ run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
 
 depends: [
   "ocaml" {>= "4.03.0"}
-  "mrmime"
-  "colombe"
-  "sendmail-lwt"
+  "mrmime" {= "0.1.0"}
+  "colombe" {= "0.1.0"}
+  "sendmail-lwt" {= "0.1.0"}
   "logs"
   "fmt"
   "astring"
@@ -25,7 +25,7 @@ depends: [
   "cmdliner"
   "domain-name" {>= "0.3.0"}
   "x509" {>= "0.7.0"}
-  "emile" {>= "0.5"}
+  "emile" {>= "0.5" <= "0.6"}
   "dune" {>= "1.3"}
 ]
 


### PR DESCRIPTION
Facteur is no more buildable against latest versions of colombe, mrmime and emile. This fixes these dependencies correctly so that it is easier to build the project.